### PR TITLE
Fix typo in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -112,7 +112,7 @@ p$predictions + ggplot2::ggtitle("Predictions")
 }
 ```
 
-We can also compare performacne by measure the relative distance between a null model and the predictions of interest as a pseudo $R^2$
+We can also compare performance by measure the relative distance between a null model and the predictions of interest as a pseudo $R^2$
 ```{r r2_plotsl, eval = FALSE}
 r2.null  <- WPR2(projected_model = dc) # should be between 0 and 1
 plot(r2.null)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ p$predictions + ggplot2::ggtitle("Predictions")
 
 <img src="man/figures/README-example_continued_plot_noecho-1.png" width="70%" />
 
-We can also compare performacne by measure the relative distance between
+We can also compare performance by measure the relative distance between
 a null model and the predictions of interest as a pseudo $R^2$
 
 ``` r

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -50,7 +50,7 @@ oem
 ols
 parallelization
 paramters
-performacne
+performance
 precomputed
 progres
 pwr


### PR DESCRIPTION
## Summary
- fix spelling of "performance" in docs
- update `inst/WORDLIST` with corrected word

## Testing
- `Rscript -e "rmarkdown::render('README.Rmd', output_format='github_document')"` *(fails: command not found)*
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476f92acd8832b97b92f7b4d210a37