### PR TITLE
Fix WPremoveone coefficient handling

### DIFF
--- a/R/WPremoveone.R
+++ b/R/WPremoveone.R
@@ -52,7 +52,7 @@ WPRM <- function(X, Y, theta, force = NULL, p = 2, ground_p = 2,
   if(calc.theta){
     output$theta  <- lapply(indices, function(i) {
       theta_temp <- matrix(0, d, S)
-      theta_temp[i,] <- theta_temp[i,,drop=FALSE] 
+      theta_temp[i, ] <- theta[i, , drop = FALSE]
       return(theta_temp)
     })
     output$eta <- lapply(output$theta, function(tt) X %*% tt)


### PR DESCRIPTION
## Summary
- correctly copy coefficients from `theta` to `theta_temp` when computing model subsets

## Testing
- `Rscript -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684770401c6c832bb084236526b57b22